### PR TITLE
Fix the execution in a Vagrant environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Role Variables
  * vagrant_timezone
  * vagrant_systemd_journal_group
 
+Requirements
+------------
+
+The following roles are required:
+
+*  [facts](https://github.com/idi-ops/ansible-facts/)
+
 Example Playbook
 ----------------
 

--- a/tasks/always.yml
+++ b/tasks/always.yml
@@ -1,0 +1,41 @@
+---
+
+- name: Configure timezone
+  file:
+    src: "/usr/share/zoneinfo/{{ vagrant_timezone }}"
+    dest: /etc/localtime
+    state: link
+
+- name: Install packages
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ vagrant_packages }}"
+
+- name: Enable systemd services
+  service:
+    name: "{{ item }}"
+    enabled: yes
+  with_items: "{{ vagrant_services }}"
+
+- name: Configure system-journal-gateway user
+  user:
+    name: systemd-journal-gateway
+    groups: "{{ vagrant_systemd_journal_group }}"
+    append: yes
+    createhome: no
+  notify: restart systemd-journal-gatewayd
+
+- name: Configure systemd journal permissions permanently (tmpfiles.d)
+  copy:
+    src: system-journal.conf
+    dest: /etc/tmpfiles.d/system-journal.conf
+    backup: no
+    owner: root
+  notify: restart systemd-journal-gatewayd
+
+- name: Start services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items: "{{ vagrant_services }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,41 +1,5 @@
 ---
 
-- name: Configure timezone
-  file:
-    src: "/usr/share/zoneinfo/{{ vagrant_timezone }}"
-    dest: /etc/localtime
-    state: link
-
-- name: Install packages
-  yum:
-    name: "{{ item }}"
-    state: latest
-  with_items: vagrant_packages
-
-- name: Enable systemd services
-  service:
-    name: "{{ item }}"
-    enabled: yes
-  with_items: vagrant_services
-
-- name: Configure system-journal-gateway user
-  user:
-    name: systemd-journal-gateway
-    groups: "{{ vagrant_systemd_journal_group }}"
-    append: yes
-    createhome: no
-  notify: restart systemd-journal-gatewayd
-
-- name: Configure systemd journal permissions permanently (tmpfiles.d)
-  copy:
-    src: system-journal.conf
-    dest: /etc/tmpfiles.d/system-journal.conf
-    backup: no
-    owner: root
-  notify: restart systemd-journal-gatewayd
-
-- name: Start services
-  service:
-    name: "{{ item }}"
-    state: started
-  with_items: vagrant_services
+- include: always.yml
+  when: is_vagrant
+  tags: ['always']


### PR DESCRIPTION
This role didn't run in a building of Packer because it lacks of the special tag 'always'. So here are some changes to fix the issue:

 * Add the special tag 'always' and split the files following the same
 approach found in other roles like https://github.com/idi-ops/ansible-facts
 * Remove some Ansible warnings about the use of variables in the
 'with_items' statements